### PR TITLE
replace framelayout to fragmentcontainerview in HomeActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.fragment:fragment:1.2.0-rc01'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     tools:context=".ui.home.HomeActivity">
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/home_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />


### PR DESCRIPTION
Hej Aleksandra! Jag testade att använda FragmentContainerView istället för FrameLayout och det verkar fungera bra. Jag tycker nog att det är bättre att använda FragmentContainerView. Du kan gärna göra merge om du tycker det är bra att använda den.